### PR TITLE
Create virtualenv in init to fix template failure on start 

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,9 +1,12 @@
 tasks:
   - init: |
-      python -m pip install --upgrade pip
-      python -m pip install Django
+      python -m venv venv
+      source venv/bin/activate
+      pip install --upgrade pip wheel setuptools
+      pip install Django
       python manage.py migrate
     command: |
+      source venv/bin/activate
       python manage.py runserver
   
 ports:


### PR DESCRIPTION
## Description

Currently, our template fails to start correctly. This PR creates virtualenv in init and installs dependencies. Previously `.gitpod.yml` installed packages in system-wide python installation, which is not preserved during prebuild generation.

## How to test
Open this PR in gitpod workspace and switch to branch `create-virtualenv`